### PR TITLE
rename softdepend key in plugin.yml to fix plugin loading

### DIFF
--- a/advanced-achievements-plugin/src/main/resources/plugin.yml
+++ b/advanced-achievements-plugin/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: AdvancedAchievements
 main: com.hm.achievement.AdvancedAchievements
 version: 9.3
 author: LucidAPs
-soft depend: [Vault,PetMaster,Essentials,PlaceholderAPI,Jobs]
+softdepend: [Vault,PetMaster,Essentials,PlaceholderAPI,Jobs]
 description: Advanced Achievements enables unique and challenging achievements. Try to collect as many as you can, earn rewards, climb the rankings and receive RP books!
 api-version: 1.17
 commands:

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 			<dependency>
 				<groupId>me.clip</groupId>
 				<artifactId>placeholderapi</artifactId>
-				<version>2.11.3</version>
+				<version>2.11.6</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Typo Fix

This fixes plugins that AAch soft depends on eg Essentials as Essentials' API will throw a Null pointer given Ess hasn't been loaded yet. 