### PR TITLE
Track broken items by their properties in the ItemBreaks category

### DIFF
--- a/advanced-achievements-api/src/main/java/com/hm/achievement/category/MultipleAchievements.java
+++ b/advanced-achievements-api/src/main/java/com/hm/achievement/category/MultipleAchievements.java
@@ -19,7 +19,8 @@ public enum MultipleAchievements implements Category {
 	PLAYERCOMMANDS("PlayerCommands", "command"),
 	CUSTOM("Custom", "customname"),
 	JOBSREBORN("JobsReborn", "jobname"),
-	EFFECTSHELD("EffectsHeld", "effect");
+	EFFECTSHELD("EffectsHeld", "effect"),
+	ITEMBREAKS("ItemBreaks", "item");
 
 	private static final Map<String, MultipleAchievements> CATEGORY_NAMES_TO_ENUM = new HashMap<>();
 	static {

--- a/advanced-achievements-api/src/main/java/com/hm/achievement/category/NormalAchievements.java
+++ b/advanced-achievements-api/src/main/java/com/hm/achievement/category/NormalAchievements.java
@@ -17,7 +17,6 @@ public enum NormalAchievements implements Category {
 	EGGS("Eggs"),
 	FISH("Fish"),
 	TREASURES("Treasures"),
-	ITEMBREAKS("ItemBreaks"),
 	EATENITEMS("EatenItems"),
 	SHEARS("Shear"),
 	MILKS("Milk"),

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
@@ -82,6 +82,7 @@ public class ConfigurationParser {
 	public void loadAndParseConfiguration() throws PluginLoadError {
 		logger.info("Backing up and loading configuration files...");
 		backupAndLoadConfiguration("config.yml", "config.yml", mainConfig);
+		migrateLegacyItemBreaksConfiguration();
 		backupAndLoadConfiguration("lang.yml", mainConfig.getString("LanguageFileName"), langConfig);
 		backupAndLoadConfiguration("gui.yml", "gui.yml", guiConfig);
 		parseHeader();
@@ -136,6 +137,21 @@ public class ConfigurationParser {
 		} catch (IOException | InvalidConfigurationException e) {
 			throw new PluginLoadError("Failed to load " + userConfigName
 					+ ". Verify its syntax on yaml-online-parser.appspot.com and use the following logs.", e);
+		}
+	}
+
+	/**
+	 * Converts the ItemBreaks section of the configuration file if it was written for a plugin version in which the
+	 * category did not have sub-categories.
+	 *
+	 * @throws PluginLoadError
+	 */
+	private void migrateLegacyItemBreaksConfiguration() throws PluginLoadError {
+		try {
+			yamlUpdater.migrateItemBreaksSection("config.yml", mainConfig);
+		} catch (IOException | InvalidConfigurationException e) {
+			throw new PluginLoadError("Failed to convert the ItemBreaks section of config.yml to the sub-category format.",
+					e);
 		}
 	}
 

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/YamlUpdater.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/YamlUpdater.java
@@ -124,15 +124,17 @@ public class YamlUpdater {
 
 	private Stream<String> extractSectionForMissingKey(List<String> defaultLines, String key) {
 		for (int i = 0; i < defaultLines.size(); ++i) {
-			if (defaultLines.get(i).startsWith(key)) {
+			// The colon matters: without it a missing 'Fish' key matches the 'FishableFish:' line, appends that
+			// section instead, and since the key is still missing does it again on every startup.
+			if (defaultLines.get(i).startsWith(key + ":")) {
 				int start = i;
 				// Include all comments lines above the missing key, if any.
-				while (defaultLines.get(start - 1).startsWith("#")) {
+				while (start > 0 && defaultLines.get(start - 1).startsWith("#")) {
 					--start;
 				}
 				int end = i + 1;
 				// Include all lines belonging to the same YAML section, i.e. starting with spaces.
-				while (defaultLines.get(end).startsWith(" ")) {
+				while (end < defaultLines.size() && defaultLines.get(end).startsWith(" ")) {
 					++end;
 				}
 				return Stream.concat(Stream.of(""), defaultLines.subList(start, end).stream());

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/YamlUpdater.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/YamlUpdater.java
@@ -9,7 +9,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -23,11 +26,16 @@ import com.hm.achievement.AdvancedAchievements;
 
 public class YamlUpdater {
 
+	private static final String ITEM_BREAKS_CATEGORY = "ItemBreaks";
+	private static final String LEGACY_ITEM_BREAKS_SUBCATEGORY = "any";
+
 	private final AdvancedAchievements plugin;
+	private final Logger logger;
 
 	@Inject
-	public YamlUpdater(AdvancedAchievements plugin) {
+	public YamlUpdater(AdvancedAchievements plugin, Logger logger) {
 		this.plugin = plugin;
+		this.logger = logger;
 	}
 
 	/**
@@ -59,6 +67,59 @@ public class YamlUpdater {
 				userConfig.load(userConfigPath.toFile());
 			}
 		}
+	}
+
+	/**
+	 * Converts an ItemBreaks section written for previous plugin versions, i.e. with thresholds directly below the
+	 * category, to the current format where thresholds live below a sub-category. The achievements are moved to the
+	 * 'any' sub-category, which matches any broken item and holds the statistics migrated in the database.
+	 *
+	 * @param userConfigName
+	 * @param userConfig
+	 * @throws InvalidConfigurationException
+	 * @throws IOException
+	 */
+	public void migrateItemBreaksSection(String userConfigName, YamlConfiguration userConfig)
+			throws InvalidConfigurationException, IOException {
+		if (!isLegacyItemBreaksSection(userConfig)) {
+			return;
+		}
+
+		Path userConfigPath = Paths.get(plugin.getDataFolder().getPath(), userConfigName);
+		List<String> lines = Files.readAllLines(userConfigPath, UTF_8);
+		List<String> updatedLines = new ArrayList<>(lines.size() + 1);
+		for (int i = 0; i < lines.size(); ++i) {
+			String line = lines.get(i);
+			updatedLines.add(line);
+			if (line.startsWith(ITEM_BREAKS_CATEGORY + ":")) {
+				updatedLines.add("  " + LEGACY_ITEM_BREAKS_SUBCATEGORY + ":");
+				// Indent all the lines belonging to the section, i.e. starting with spaces.
+				while (i + 1 < lines.size() && lines.get(i + 1).startsWith(" ")) {
+					updatedLines.add("  " + lines.get(++i));
+				}
+			}
+		}
+
+		logger.info("Converting the " + ITEM_BREAKS_CATEGORY + " section of " + userConfigName
+				+ " to the sub-category format, its achievements are now below the '" + LEGACY_ITEM_BREAKS_SUBCATEGORY
+				+ "' sub-category.");
+		Files.write(userConfigPath, updatedLines);
+		userConfig.load(userConfigPath.toFile());
+	}
+
+	/**
+	 * Determines whether the ItemBreaks section uses the old format, i.e. thresholds are used as keys instead of
+	 * sub-categories.
+	 *
+	 * @param userConfig
+	 * @return true if the section must be converted, false otherwise
+	 */
+	private boolean isLegacyItemBreaksSection(YamlConfiguration userConfig) {
+		if (!userConfig.isConfigurationSection(ITEM_BREAKS_CATEGORY)) {
+			return false;
+		}
+		Set<String> keys = userConfig.getConfigurationSection(ITEM_BREAKS_CATEGORY).getKeys(false);
+		return !keys.isEmpty() && keys.stream().allMatch(StringUtils::isNumeric);
 	}
 
 	private Stream<String> extractSectionForMissingKey(List<String> defaultLines, String key) {

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/db/AbstractDatabaseManager.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/db/AbstractDatabaseManager.java
@@ -103,7 +103,11 @@ public abstract class AbstractDatabaseManager implements Reloadable {
 
 		databaseUpdater.renameExistingTables(this);
 		int size = mainConfig.getInt("TableMaxSizeOfGroupedSubcategories");
+		boolean legacyItemBreaksDataToCopy = databaseUpdater.renameLegacyItemBreaksTable(this);
 		databaseUpdater.initialiseTables(this, size);
+		if (legacyItemBreaksDataToCopy) {
+			databaseUpdater.copyLegacyItemBreaksData(this);
+		}
 		Arrays.stream(MultipleAchievements.values()).forEach(m -> databaseUpdater.updateOldDBColumnSize(this, m, size));
 		initialised = true;
 	}

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/db/DatabaseUpdater.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/db/DatabaseUpdater.java
@@ -1,6 +1,7 @@
 package com.hm.achievement.db;
 
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.logging.Level;
@@ -23,6 +24,9 @@ import com.hm.achievement.exception.PluginLoadError;
  */
 @Singleton
 public class DatabaseUpdater {
+
+	private static final String LEGACY_TABLE_SUFFIX = "_legacy";
+	private static final String LEGACY_ITEMBREAKS_SUBCATEGORY = "any";
 
 	private final Logger logger;
 
@@ -97,6 +101,73 @@ public class DatabaseUpdater {
 			st.executeBatch();
 		} catch (SQLException e) {
 			throw new PluginLoadError("Error while initialising database tables.", e);
+		}
+	}
+
+	/**
+	 * Renames the itembreaks table if it still uses the old schema of the days when ItemBreaks was a category without
+	 * sub-categories. The renamed table is kept as a backup and its data is copied over by
+	 * {@link #copyLegacyItemBreaksData(AbstractDatabaseManager)} once the new table has been created.
+	 *
+	 * @param databaseManager
+	 * @return true if a legacy table was renamed and its data must be copied over, false otherwise
+	 */
+	boolean renameLegacyItemBreaksTable(AbstractDatabaseManager databaseManager) {
+		String table = databaseManager.getPrefix() + MultipleAchievements.ITEMBREAKS.toDBName();
+		try (Statement st = databaseManager.getConnection().createStatement()) {
+			if (!tableExistsWithoutSubcategoryColumn(st, table)) {
+				return false;
+			}
+			logger.info("Converting the " + table + " table to the sub-category format, please wait...");
+			st.execute("DROP TABLE IF EXISTS " + table + LEGACY_TABLE_SUFFIX);
+			st.execute("ALTER TABLE " + table + " RENAME TO " + table + LEGACY_TABLE_SUFFIX);
+			return true;
+		} catch (SQLException e) {
+			logger.log(Level.SEVERE, "Database error while converting the old " + table + " table:", e);
+			return false;
+		}
+	}
+
+	/**
+	 * Copies the statistics of the legacy itembreaks table into the 'any' sub-category of the new one. The legacy table
+	 * is left in the database as a backup.
+	 *
+	 * @param databaseManager
+	 */
+	void copyLegacyItemBreaksData(AbstractDatabaseManager databaseManager) {
+		String dbName = MultipleAchievements.ITEMBREAKS.toDBName();
+		String table = databaseManager.getPrefix() + dbName;
+		String legacyTable = table + LEGACY_TABLE_SUFFIX;
+		try (Statement st = databaseManager.getConnection().createStatement()) {
+			int migrated = st.executeUpdate("INSERT INTO " + table + " (playername, "
+					+ MultipleAchievements.ITEMBREAKS.toSubcategoryDBName() + ", " + dbName + ") SELECT playername, '"
+					+ LEGACY_ITEMBREAKS_SUBCATEGORY + "', " + dbName + " FROM " + legacyTable);
+			logger.info("Converted " + migrated + " " + dbName + " statistics to the '" + LEGACY_ITEMBREAKS_SUBCATEGORY
+					+ "' sub-category. The previous data was kept in the " + legacyTable + " table.");
+		} catch (SQLException e) {
+			logger.log(Level.SEVERE, "Database error while copying the old " + table + " statistics:", e);
+		}
+	}
+
+	/**
+	 * Determines whether the table exists and is missing the sub-category column of the ItemBreaks category.
+	 *
+	 * @param st
+	 * @param table
+	 * @return true if the table uses the old schema, false if it does not exist or already has the column
+	 */
+	private boolean tableExistsWithoutSubcategoryColumn(Statement st, String table) {
+		try (ResultSet rs = st.executeQuery("SELECT * FROM " + table + " WHERE 1 = 0")) {
+			ResultSetMetaData metaData = rs.getMetaData();
+			for (int column = 1; column <= metaData.getColumnCount(); ++column) {
+				if (MultipleAchievements.ITEMBREAKS.toSubcategoryDBName().equalsIgnoreCase(metaData.getColumnName(column))) {
+					return false;
+				}
+			}
+			return true;
+		} catch (SQLException tableDoesNotExist) {
+			// Fresh installation, or table renamed by a previous run: nothing to convert.
+			return false;
 		}
 	}
 

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/ItemBreaksListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/ItemBreaksListener.java
@@ -1,35 +1,80 @@
 package com.hm.achievement.listener.statistics;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.inventory.ItemStack;
 
-import com.hm.achievement.category.NormalAchievements;
+import com.hm.achievement.category.MultipleAchievements;
 import com.hm.achievement.config.AchievementMap;
 import com.hm.achievement.db.CacheManager;
+import com.hm.achievement.utils.ItemFilter;
+import com.hm.achievement.utils.MaterialHelper;
 
 /**
- * Listener class to deal with ItemBreaks achievements.
- * 
+ * Listener class to deal with ItemBreaks achievements. Sub-categories describe the broken item: its material and,
+ * optionally, its enchantments, custom name, colour or unbreakable flag. See {@link ItemFilter} for the syntax.
+ *
  * @author Pyves
  *
  */
 @Singleton
 public class ItemBreaksListener extends AbstractListener {
 
+	private final MaterialHelper materialHelper;
+	private final Logger logger;
+
+	private Map<String, ItemFilter> subcategoriesToFilters = new HashMap<>();
+
 	@Inject
 	public ItemBreaksListener(@Named("main") YamlConfiguration mainConfig, AchievementMap achievementMap,
-			CacheManager cacheManager) {
-		super(NormalAchievements.ITEMBREAKS, mainConfig, achievementMap, cacheManager);
+			CacheManager cacheManager, MaterialHelper materialHelper, Logger logger) {
+		super(MultipleAchievements.ITEMBREAKS, mainConfig, achievementMap, cacheManager);
+		this.materialHelper = materialHelper;
+		this.logger = logger;
+	}
+
+	@Override
+	public void extractConfigurationParameters() {
+		super.extractConfigurationParameters();
+		Map<String, ItemFilter> filters = new HashMap<>();
+		for (String subcategory : subcategories) {
+			filters.put(subcategory, ItemFilter.parse(subcategory, materialHelper, logger));
+		}
+		subcategoriesToFilters = filters;
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onPlayerItemBreak(PlayerItemBreakEvent event) {
-		updateStatisticAndAwardAchievementsIfAvailable(event.getPlayer(), 1);
+		Player player = event.getPlayer();
+		ItemStack brokenItem = event.getBrokenItem();
+		if (!player.hasPermission(category.toChildPermName(brokenItem.getType().name().toLowerCase(Locale.ROOT)))) {
+			return;
+		}
+
+		Set<String> matchingSubcategories = new HashSet<>();
+		subcategoriesToFilters.forEach((subcategory, filter) -> {
+			if (filter.matches(brokenItem)) {
+				matchingSubcategories.add(subcategory);
+			}
+		});
+		if (matchingSubcategories.isEmpty()) {
+			return;
+		}
+
+		updateStatisticAndAwardAchievementsIfAvailable(player, matchingSubcategories, 1);
 	}
 }

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/ItemBreaksListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/ItemBreaksListener.java
@@ -2,7 +2,6 @@ package com.hm.achievement.listener.statistics;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -11,6 +10,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -61,13 +61,14 @@ public class ItemBreaksListener extends AbstractListener {
 	public void onPlayerItemBreak(PlayerItemBreakEvent event) {
 		Player player = event.getPlayer();
 		ItemStack brokenItem = event.getBrokenItem();
-		if (!player.hasPermission(category.toChildPermName(brokenItem.getType().name().toLowerCase(Locale.ROOT)))) {
-			return;
-		}
 
 		Set<String> matchingSubcategories = new HashSet<>();
 		subcategoriesToFilters.forEach((subcategory, filter) -> {
-			if (filter.matches(brokenItem)) {
+			// Permissions are registered per alternative of a sub-category key, so the matching alternative is what the
+			// permission node has to be built from.
+			String alternative = filter.matchingAlternative(brokenItem);
+			if (alternative != null
+					&& player.hasPermission(category.toChildPermName(StringUtils.deleteWhitespace(alternative)))) {
 				matchingSubcategories.add(subcategory);
 			}
 		});

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/ItemFilter.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/ItemFilter.java
@@ -1,0 +1,286 @@
+package com.hm.achievement.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Color;
+import org.bukkit.DyeColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+
+/**
+ * Filter matching an ItemStack against the properties described by a sub-category key, used by the ItemBreaks category.
+ * <p>
+ * A key is made of alternatives separated by {@code |}; each alternative is made of conditions separated by {@code ;}
+ * that must all be satisfied. The supported conditions are:
+ * <ul>
+ * <li>{@code any}: matches any item;</li>
+ * <li>{@code <material>} or {@code material:<material>}: e.g. {@code netherite_leggings};</li>
+ * <li>{@code enchant:<name>[:<level>]}: e.g. {@code enchant:mending} or {@code enchant:unbreaking:3}; the level also
+ * accepts the {@code >=}, {@code <=}, {@code >} and {@code <} operators, e.g. {@code enchant:unbreaking:>=2};</li>
+ * <li>{@code name:<display name>}: case insensitive, formatting codes are ignored; {@code name:*} matches any item
+ * with a custom name;</li>
+ * <li>{@code color:<dye colour|#RRGGBB|r,g,b>}: colour of a dyed leather armour piece, e.g. {@code color:purple};</li>
+ * <li>{@code unbreakable}: the item has the unbreakable flag.</li>
+ * </ul>
+ * For example {@code leather_leggings;color:purple;name:Purple Shorts} matches purple leather leggings named
+ * "Purple Shorts", and {@code wooden_hoe;enchant:unbreaking:3|netherite_leggings} matches either a wooden hoe with
+ * Unbreaking III or any pair of netherite leggings.
+ */
+public class ItemFilter {
+
+	private static final Pattern LEVEL_PATTERN = Pattern.compile("(>=|<=|>|<|=)?\\d+");
+
+	private final List<List<Predicate<ItemStack>>> alternatives;
+
+	private ItemFilter(List<List<Predicate<ItemStack>>> alternatives) {
+		this.alternatives = alternatives;
+	}
+
+	/**
+	 * Parses a sub-category key into a filter. Invalid conditions are logged and never match any item.
+	 *
+	 * @param key the sub-category key, as written in the configuration file
+	 * @param materialHelper used to match the material conditions
+	 * @param logger used to report invalid conditions
+	 * @return the corresponding filter
+	 */
+	public static ItemFilter parse(String key, MaterialHelper materialHelper, Logger logger) {
+		List<List<Predicate<ItemStack>>> alternatives = new ArrayList<>();
+		for (String alternative : StringUtils.split(key, '|')) {
+			List<Predicate<ItemStack>> conditions = new ArrayList<>();
+			for (String condition : StringUtils.split(alternative, ';')) {
+				if (StringUtils.isNotBlank(condition)) {
+					conditions.add(parseCondition(condition.trim(), key, materialHelper, logger));
+				}
+			}
+			if (!conditions.isEmpty()) {
+				alternatives.add(conditions);
+			}
+		}
+		return new ItemFilter(alternatives);
+	}
+
+	/**
+	 * Determines whether the item satisfies all the conditions of at least one of the alternatives of the key.
+	 *
+	 * @param item the item to match
+	 * @return true if the item matches the key, false otherwise
+	 */
+	public boolean matches(ItemStack item) {
+		for (List<Predicate<ItemStack>> conditions : alternatives) {
+			boolean matchesAllConditions = true;
+			for (Predicate<ItemStack> condition : conditions) {
+				if (!condition.test(item)) {
+					matchesAllConditions = false;
+					break;
+				}
+			}
+			if (matchesAllConditions) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static Predicate<ItemStack> parseCondition(String condition, String key, MaterialHelper materialHelper,
+			Logger logger) {
+		int separatorIndex = condition.indexOf(':');
+		String type = (separatorIndex < 0 ? condition : condition.substring(0, separatorIndex)).trim()
+				.toLowerCase(Locale.ROOT);
+		String value = separatorIndex < 0 ? "" : condition.substring(separatorIndex + 1).trim();
+
+		switch (type) {
+			case "any":
+			case "*":
+				return item -> true;
+			case "material":
+			case "item":
+				return parseMaterialCondition(value, key, materialHelper);
+			case "enchant":
+			case "enchantment":
+				return parseEnchantmentCondition(value, key, logger);
+			case "name":
+				return parseNameCondition(value, key, logger);
+			case "color":
+			case "colour":
+				return parseColorCondition(value, key, logger);
+			case "unbreakable":
+				return item -> {
+					ItemMeta meta = item.getItemMeta();
+					return meta != null && meta.isUnbreakable();
+				};
+			default:
+				if (separatorIndex < 0) {
+					// A condition without a value is a material name, e.g. 'netherite_leggings'.
+					return parseMaterialCondition(type, key, materialHelper);
+				}
+				logger.warning("Condition \"" + condition + "\" used in the ItemBreaks sub-category \"" + key
+						+ "\" is unknown. Supported conditions are: any, material, enchant, name, color and unbreakable.");
+				return item -> false;
+		}
+	}
+
+	private static Predicate<ItemStack> parseMaterialCondition(String value, String key,
+			MaterialHelper materialHelper) {
+		Material material = materialHelper.matchMaterial(value, null, "the ItemBreaks sub-category \"" + key + "\"");
+		if (material == null) {
+			return item -> false;
+		}
+		return item -> item.getType() == material;
+	}
+
+	private static Predicate<ItemStack> parseEnchantmentCondition(String value, String key, Logger logger) {
+		if (value.isEmpty()) {
+			logger.warning("The enchant condition used in the ItemBreaks sub-category \"" + key
+					+ "\" is missing an enchantment name, for example enchant:mending.");
+			return item -> false;
+		}
+		// The level, if any, follows the name of the enchantment. Namespaced names such as minecraft:mending are also
+		// supported, hence the level is only extracted when the last part of the value looks like one.
+		String enchantmentName = value;
+		IntPredicate levelPredicate = level -> true;
+		int levelIndex = value.lastIndexOf(':');
+		if (levelIndex >= 0 && LEVEL_PATTERN.matcher(value.substring(levelIndex + 1).trim()).matches()) {
+			enchantmentName = value.substring(0, levelIndex).trim();
+			levelPredicate = parseLevelPredicate(value.substring(levelIndex + 1).trim(), key, logger);
+			if (levelPredicate == null) {
+				return item -> false;
+			}
+		}
+		String expectedEnchantmentName = enchantmentName.toLowerCase(Locale.ROOT);
+		IntPredicate expectedLevel = levelPredicate;
+		return item -> {
+			ItemMeta meta = item.getItemMeta();
+			if (meta == null) {
+				return false;
+			}
+			for (Map.Entry<Enchantment, Integer> enchantment : meta.getEnchants().entrySet()) {
+				if (matchesEnchantmentName(enchantment.getKey().getKey(), expectedEnchantmentName)
+						&& expectedLevel.test(enchantment.getValue())) {
+					return true;
+				}
+			}
+			return false;
+		};
+	}
+
+	/**
+	 * Determines whether the key of an enchantment matches the name used in the configuration, either in its short form
+	 * (unbreaking) or in its namespaced one (minecraft:unbreaking).
+	 *
+	 * @param key the key of the enchantment carried by the item
+	 * @param name the lower case name used in the configuration
+	 * @return true if the enchantment matches the name, false otherwise
+	 */
+	static boolean matchesEnchantmentName(NamespacedKey key, String name) {
+		return name.equals(key.getKey().toLowerCase(Locale.ROOT)) || name.equals(key.toString().toLowerCase(Locale.ROOT));
+	}
+
+	/**
+	 * Parses the level part of an enchant condition, e.g. '3' or '>=2'.
+	 *
+	 * @param value the level, optionally prefixed by a comparison operator
+	 * @param key used for logging
+	 * @param logger used to report an invalid level
+	 * @return the predicate on the enchantment level, or null if the level could not be parsed
+	 */
+	static IntPredicate parseLevelPredicate(String value, String key, Logger logger) {
+		String operator = "";
+		for (String candidate : Arrays.asList(">=", "<=", ">", "<", "=")) {
+			if (value.startsWith(candidate)) {
+				operator = candidate;
+				break;
+			}
+		}
+		String levelValue = value.substring(operator.length()).trim();
+		int level;
+		try {
+			level = Integer.parseInt(levelValue);
+		} catch (NumberFormatException e) {
+			logger.warning("Enchantment level \"" + value + "\" used in the ItemBreaks sub-category \"" + key
+					+ "\" is not a valid number, for example enchant:unbreaking:3 or enchant:unbreaking:>=3.");
+			return null;
+		}
+		switch (operator) {
+			case ">=":
+				return itemLevel -> itemLevel >= level;
+			case "<=":
+				return itemLevel -> itemLevel <= level;
+			case ">":
+				return itemLevel -> itemLevel > level;
+			case "<":
+				return itemLevel -> itemLevel < level;
+			default:
+				return itemLevel -> itemLevel == level;
+		}
+	}
+
+	private static Predicate<ItemStack> parseNameCondition(String value, String key, Logger logger) {
+		if (value.isEmpty()) {
+			logger.warning("The name condition used in the ItemBreaks sub-category \"" + key
+					+ "\" is missing a value, for example name:Purple Shorts or name:* for any custom name.");
+			return item -> false;
+		}
+		if ("*".equals(value)) {
+			return item -> {
+				ItemMeta meta = item.getItemMeta();
+				return meta != null && meta.hasDisplayName();
+			};
+		}
+		String expectedName = StringHelper.removeFormattingCodes(value).trim();
+		return item -> {
+			ItemMeta meta = item.getItemMeta();
+			if (meta == null || !meta.hasDisplayName()) {
+				return false;
+			}
+			return StringHelper.removeFormattingCodes(meta.getDisplayName()).trim().equalsIgnoreCase(expectedName);
+		};
+	}
+
+	private static Predicate<ItemStack> parseColorCondition(String value, String key, Logger logger) {
+		Color color = parseColor(value);
+		if (color == null) {
+			logger.warning("Colour \"" + value + "\" used in the ItemBreaks sub-category \"" + key
+					+ "\" is invalid. Use a dye colour name (e.g. purple), a hexadecimal value (e.g. #8932b8) or "
+					+ "comma-separated RGB components (e.g. 137,50,184).");
+			return item -> false;
+		}
+		return item -> {
+			ItemMeta meta = item.getItemMeta();
+			return meta instanceof LeatherArmorMeta && color.equals(((LeatherArmorMeta) meta).getColor());
+		};
+	}
+
+	private static Color parseColor(String value) {
+		try {
+			if (value.contains(",")) {
+				String[] components = StringUtils.split(value, ',');
+				if (components.length != 3) {
+					return null;
+				}
+				return Color.fromRGB(Integer.parseInt(components[0].trim()), Integer.parseInt(components[1].trim()),
+						Integer.parseInt(components[2].trim()));
+			}
+			if (value.startsWith("#")) {
+				return Color.fromRGB(Integer.parseInt(value.substring(1).trim(), 16));
+			}
+			return DyeColor.valueOf(value.toUpperCase(Locale.ROOT).replace(' ', '_')).getColor();
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
+
+}

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/ItemFilter.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/ItemFilter.java
@@ -43,10 +43,34 @@ public class ItemFilter {
 
 	private static final Pattern LEVEL_PATTERN = Pattern.compile("(>=|<=|>|<|=)?\\d+");
 
-	private final List<List<Predicate<ItemStack>>> alternatives;
+	private final List<Alternative> alternatives;
 
-	private ItemFilter(List<List<Predicate<ItemStack>>> alternatives) {
+	private ItemFilter(List<Alternative> alternatives) {
 		this.alternatives = alternatives;
+	}
+
+	/**
+	 * One of the '|' separated alternatives of a sub-category key, with the conditions it is made of and the text it was
+	 * written as. The text is what the permission node of the alternative is built from.
+	 */
+	private static class Alternative {
+
+		private final String key;
+		private final List<Predicate<ItemStack>> conditions;
+
+		private Alternative(String key, List<Predicate<ItemStack>> conditions) {
+			this.key = key;
+			this.conditions = conditions;
+		}
+
+		private boolean matches(ItemStack item) {
+			for (Predicate<ItemStack> condition : conditions) {
+				if (!condition.test(item)) {
+					return false;
+				}
+			}
+			return true;
+		}
 	}
 
 	/**
@@ -58,7 +82,7 @@ public class ItemFilter {
 	 * @return the corresponding filter
 	 */
 	public static ItemFilter parse(String key, MaterialHelper materialHelper, Logger logger) {
-		List<List<Predicate<ItemStack>>> alternatives = new ArrayList<>();
+		List<Alternative> alternatives = new ArrayList<>();
 		for (String alternative : StringUtils.split(key, '|')) {
 			List<Predicate<ItemStack>> conditions = new ArrayList<>();
 			for (String condition : StringUtils.split(alternative, ';')) {
@@ -67,7 +91,7 @@ public class ItemFilter {
 				}
 			}
 			if (!conditions.isEmpty()) {
-				alternatives.add(conditions);
+				alternatives.add(new Alternative(alternative.trim(), conditions));
 			}
 		}
 		return new ItemFilter(alternatives);
@@ -80,19 +104,24 @@ public class ItemFilter {
 	 * @return true if the item matches the key, false otherwise
 	 */
 	public boolean matches(ItemStack item) {
-		for (List<Predicate<ItemStack>> conditions : alternatives) {
-			boolean matchesAllConditions = true;
-			for (Predicate<ItemStack> condition : conditions) {
-				if (!condition.test(item)) {
-					matchesAllConditions = false;
-					break;
-				}
-			}
-			if (matchesAllConditions) {
-				return true;
+		return matchingAlternative(item) != null;
+	}
+
+	/**
+	 * Returns the first alternative of the key whose conditions are all satisfied by the item, as it was written in the
+	 * configuration file. Permissions are registered per alternative rather than per key, so this is what the caller
+	 * must build the permission node of the match from.
+	 *
+	 * @param item the item to match
+	 * @return the matching alternative, or null if the item matches none of them
+	 */
+	public String matchingAlternative(ItemStack item) {
+		for (Alternative alternative : alternatives) {
+			if (alternative.matches(item)) {
+				return alternative.key;
 			}
 		}
-		return false;
+		return null;
 	}
 
 	private static Predicate<ItemStack> parseCondition(String condition, String key, MaterialHelper materialHelper,

--- a/advanced-achievements-plugin/src/main/resources/config-CN.yml
+++ b/advanced-achievements-plugin/src/main/resources/config-CN.yml
@@ -458,6 +458,23 @@ JobsReborn:
       DisplayName: Hunter
       Type: normal
 
+# 当工具/防具/武器 被用坏，子类别用于描述被用坏的物品，多个条件用 ';' 分隔，全部满足才会计数。可用条件：
+# - any: 任何被用坏的物品（插件旧版本的统计数据会迁移到这里）
+# - <material> 或 material:<material>: 小写的物品名称，例如 netherite_leggings
+# - enchant:<name>[:<level>]: 原版附魔名称，例如 enchant:mending 或 enchant:unbreaking:3，等级还支持 >=、<=、> 和 < 运算符
+# - name:<display name>: 物品的自定义名称，忽略大小写和颜色代码，name:* 表示任何被重命名的物品
+# - color:<colour>: 已染色皮革护甲的颜色，可以是染料颜色名称（例如 purple）、十六进制值（例如 "#8932b8"）或 RGB（例如 137,50,184）
+# - unbreakable: 物品带有无法破坏（unbreakable）标签
+# 和其他拥有子类别的类别一样，可以用 '|' 组合，例如 wooden_hoe|stone_hoe
+ItemBreaks:
+  any:
+    1:
+      Goal: 把一个工具用坏掉吧
+      Message: 你用坏了你的第一个工具！
+      Name: itembreaks_1
+      DisplayName: §4工具破坏者
+      Type: normal
+
 #======================================================================================================================#
 #                                                        简单行为成就                                                   #
 #                                                                                                                      #
@@ -530,15 +547,6 @@ Treasures:
     Message: 你获得来自大海的第一个宝物！
     Name: treasure_1
     DisplayName: 宝物猎人、
-    Type: normal
-
-# 当工具/防具/武器 被用坏
-ItemBreaks:
-  1:
-    Goal: 把一个工具用坏掉吧
-    Message: 你用坏了你的第一个工具！
-    Name: itembreaks_1
-    DisplayName: §4工具破坏者
     Type: normal
 
 # 吃一个东西（除药水和牛奶）

--- a/advanced-achievements-plugin/src/main/resources/config.yml
+++ b/advanced-achievements-plugin/src/main/resources/config.yml
@@ -619,6 +619,48 @@ EffectsHeld:
       DisplayName: Kangaroo
       Type: normal
 
+# Count tools, armors or weapons broken, by item. A sub-category key describes the broken item with conditions
+# separated by ';'; all of them must be satisfied. Available conditions:
+# - any: matches any broken item (this is where statistics of previous plugin versions were migrated to).
+# - <material> or material:<material>: material name in lower case, e.g. netherite_leggings.
+# - enchant:<name>[:<level>]: vanilla enchantment name, e.g. enchant:mending or enchant:unbreaking:3. The level also
+#   supports the >=, <=, > and < operators, e.g. enchant:unbreaking:>=2.
+# - name:<display name>: custom item name; case and colour codes are ignored. Use name:* for any renamed item.
+# - color:<colour>: colour of a dyed leather armor piece, either a dye colour name (e.g. purple), a hexadecimal value
+#   (e.g. "#8932b8") or comma-separated RGB components (e.g. 137,50,184).
+# - unbreakable: the item has the unbreakable flag.
+# As for other categories with sub-categories, groups are supported with '|', e.g. wooden_hoe|stone_hoe. Keep the total
+# length of a key below the TableMaxSizeOfGroupedSubcategories parameter.
+ItemBreaks:
+  any:
+    1:
+      Goal: Let an item break.
+      Message: You broke your favorite tool!
+      Name: itembreaks_1
+      DisplayName: §4Clumsy Guy
+      Type: normal
+  netherite_leggings:
+    1:
+      Goal: Wear out a pair of netherite leggings.
+      Message: You wore your netherite leggings down to nothing!
+      Name: itembreaks_1_netherite_leggings
+      DisplayName: Bare Legs
+      Type: normal
+  "wooden_hoe;enchant:unbreaking:3":
+    1:
+      Goal: Break a wooden hoe enchanted with Unbreaking III.
+      Message: Even Unbreaking III could not save that hoe!
+      Name: itembreaks_1_unbreaking_wooden_hoe
+      DisplayName: Sturdy Farmer
+      Type: normal
+  "leather_leggings;color:purple;name:Purple Shorts":
+    1:
+      Goal: Break your purple shorts.
+      Message: Your Purple Shorts fell apart!
+      Name: itembreaks_1_purple_shorts
+      DisplayName: Purple Reign
+      Type: normal
+
 #======================================================================================================================#
 #                                              NORMAL ACTION ACHIEVEMENTS                                              #
 #                                                                                                                      #
@@ -691,15 +733,6 @@ Treasures:
     Message: Your first treasure from the sea!
     Name: treasure_1
     DisplayName: Treasure Hunter
-    Type: normal
-
-# Count tools, armors or weapons broken.
-ItemBreaks:
-  1:
-    Goal: Let an item break.
-    Message: You broke your favorite tool!
-    Name: itembreaks_1
-    DisplayName: §4Clumsy Guy
     Type: normal
 
 # Count items eaten (excludes potions and milk).

--- a/advanced-achievements-plugin/src/main/resources/plugin.yml
+++ b/advanced-achievements-plugin/src/main/resources/plugin.yml
@@ -309,7 +309,8 @@ permissions:
 # For categories with sub-categories (Breaks, Places, Crafts, Kills, Breeding, PlayerCommands, Custom, TargetsShot,
 # EffectsHeld and ItemBreaks):
 # - use the sub-category key: for example for stone breaks, achievement.count.breaks.stone
-# - for ItemBreaks, use the material of the broken item: for example achievement.count.itembreaks.wooden_hoe
+# - for ItemBreaks, use the sub-category key, whitespaces removed: achievement.count.itembreaks.netherite_leggings,
+#   achievement.count.itembreaks.any or achievement.count.itembreaks.wooden_hoe;enchant:unbreaking:3
 # - for PlayerCommands, use lower case without spaces nor the initial slash: achievement.count.playercommands.aachbook
 # - for Kills with a custom mob name you should remove any whitespaces: achievement.count.kills.§2SkeletalKnight
 # - for Places with a custom item display name you should also remove any whitespaces.

--- a/advanced-achievements-plugin/src/main/resources/plugin.yml
+++ b/advanced-achievements-plugin/src/main/resources/plugin.yml
@@ -101,7 +101,6 @@ permissions:
       achievement.count.fireworks: true
       achievement.count.musicdiscs: true
       achievement.count.enderpearls: true
-      achievement.count.itembreaks: true
       achievement.count.milk: true
       achievement.count.shear: true
       achievement.count.snowballs: true
@@ -140,6 +139,7 @@ permissions:
       achievement.count.jobsreborn.*: true
       achievement.count.custom.*: true
       achievement.count.effectsheld.*: true
+      achievement.count.itembreaks.*: true
   achievement.count.connections:
     description: Allows connection statistics in database to increase.
     default: true
@@ -184,9 +184,6 @@ permissions:
     default: true
   achievement.count.enderpearls:
     description: Allows ender pearl statistics in database to increase.
-    default: true
-  achievement.count.itembreaks:
-    description: Allows item breaks statistics in database to increase.
     default: true
   achievement.count.milk:
     description: Allows milk statistics in database to increase.
@@ -302,12 +299,17 @@ permissions:
   achievement.count.effectsheld.*:
     description: Allows effects held statistics in database to increase.
     default: true
+  achievement.count.itembreaks.*:
+    description: Allows item breaks statistics in database to increase.
+    default: true
 #======================================================================================================================#
 #                                /!\  Dynamic permissions added at plugin startup  /!\                                 #
 #======================================================================================================================#
 # For individual achievements, simply use the Name property, e.g achievement.place_100_stone
-# For categories with sub-categories (Breaks, Places, Crafts, Kills, Breeding, PlayerCommands, Custom, TargetsShot and EffectsHeld):
+# For categories with sub-categories (Breaks, Places, Crafts, Kills, Breeding, PlayerCommands, Custom, TargetsShot,
+# EffectsHeld and ItemBreaks):
 # - use the sub-category key: for example for stone breaks, achievement.count.breaks.stone
+# - for ItemBreaks, use the material of the broken item: for example achievement.count.itembreaks.wooden_hoe
 # - for PlayerCommands, use lower case without spaces nor the initial slash: achievement.count.playercommands.aachbook
 # - for Kills with a custom mob name you should remove any whitespaces: achievement.count.kills.§2SkeletalKnight
 # - for Places with a custom item display name you should also remove any whitespaces.

--- a/advanced-achievements-plugin/src/test/java/com/hm/achievement/config/YamlUpdaterTest.java
+++ b/advanced-achievements-plugin/src/test/java/com/hm/achievement/config/YamlUpdaterTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.logging.Logger;
 
@@ -73,6 +74,22 @@ class YamlUpdaterTest {
 		underTest.update("config-default.yml", userFile.getName(), YamlConfiguration.loadConfiguration(userFile));
 
 		assertEquals(lastModified, userFile.lastModified());
+	}
+
+	@Test
+	void shouldAppendTheMissingKeyRatherThanOneItIsAPrefixOf() throws Exception {
+		when(plugin.getResource("config-prefix-default.yml"))
+				.thenReturn(getClass().getResourceAsStream("/config-prefix-default.yml"));
+		when(plugin.getDataFolder()).thenReturn(tempDir);
+		File userFile = createFileFromTestResource("config-prefix-user.yml");
+		YamlConfiguration config = YamlConfiguration.loadConfiguration(userFile);
+
+		underTest.update("config-prefix-default.yml", userFile.getName(), config);
+
+		// 'Fish' is a prefix of the 'FishableFish' key the user already has, which must not be appended again.
+		assertEquals("fish_1", config.getString("Fish.1.Name"));
+		assertEquals(Arrays.asList("cod", "salmon"), config.getStringList("FishableFish"));
+		assertEquals(1, Files.readAllLines(userFile.toPath()).stream().filter(l -> l.startsWith("FishableFish:")).count());
 	}
 
 	@Test

--- a/advanced-achievements-plugin/src/test/java/com/hm/achievement/config/YamlUpdaterTest.java
+++ b/advanced-achievements-plugin/src/test/java/com/hm/achievement/config/YamlUpdaterTest.java
@@ -1,12 +1,15 @@
 package com.hm.achievement.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.logging.Logger;
 
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +24,8 @@ import com.hm.achievement.AdvancedAchievements;
 @ExtendWith(MockitoExtension.class)
 class YamlUpdaterTest {
 
+	private static final Logger LOGGER = Logger.getLogger("YamlUpdaterTestLogger");
+
 	@TempDir
 	static File tempDir;
 
@@ -30,13 +35,13 @@ class YamlUpdaterTest {
 	private YamlUpdater underTest;
 
 	@BeforeEach
-	void setUp() throws Exception {
-		when(plugin.getResource("config-default.yml")).thenReturn(getClass().getResourceAsStream("/config-default.yml"));
-		underTest = new YamlUpdater(plugin);
+	void setUp() {
+		underTest = new YamlUpdater(plugin, LOGGER);
 	}
 
 	@Test
 	void shouldAppendMissingDefaultSectionsToUserConfiguration() throws Exception {
+		mockDefaultConfigResource();
 		when(plugin.getDataFolder()).thenReturn(tempDir);
 		File userFile = createFileFromTestResource("config-missing-sections.yml");
 
@@ -49,6 +54,7 @@ class YamlUpdaterTest {
 
 	@Test
 	void shouldReloadConfigurationIfThereWereMissingSections() throws Exception {
+		mockDefaultConfigResource();
 		when(plugin.getDataFolder()).thenReturn(tempDir);
 		File userFile = createFileFromTestResource("config-missing-sections.yml");
 		YamlConfiguration config = YamlConfiguration.loadConfiguration(userFile);
@@ -60,12 +66,45 @@ class YamlUpdaterTest {
 
 	@Test
 	void shouldNotChangeUserConfigIfThereAreNoMissingKeys() throws Exception {
+		mockDefaultConfigResource();
 		File userFile = createFileFromTestResource("config-default.yml");
 		long lastModified = userFile.lastModified();
 
 		underTest.update("config-default.yml", userFile.getName(), YamlConfiguration.loadConfiguration(userFile));
 
 		assertEquals(lastModified, userFile.lastModified());
+	}
+
+	@Test
+	void shouldMoveLegacyItemBreaksAchievementsToAnySubcategory() throws Exception {
+		when(plugin.getDataFolder()).thenReturn(tempDir);
+		File userFile = createFileFromTestResource("config-legacy-itembreaks.yml");
+		YamlConfiguration config = YamlConfiguration.loadConfiguration(userFile);
+
+		underTest.migrateItemBreaksSection(userFile.getName(), config);
+
+		assertEquals(Collections.singleton("any"), config.getConfigurationSection("ItemBreaks").getKeys(false));
+		assertEquals("itembreaks_1", config.getString("ItemBreaks.any.1.Name"));
+		// Other categories must not be affected by the conversion.
+		assertEquals("eatenitems_1", config.getString("EatenItems.1.Name"));
+	}
+
+	@Test
+	void shouldNotChangeItemBreaksSectionAlreadyUsingSubcategories() throws Exception {
+		when(plugin.getDataFolder()).thenReturn(tempDir);
+		File userFile = createFileFromTestResource("config-legacy-itembreaks.yml");
+		YamlConfiguration config = YamlConfiguration.loadConfiguration(userFile);
+		underTest.migrateItemBreaksSection(userFile.getName(), config);
+		long lastModified = userFile.lastModified();
+
+		underTest.migrateItemBreaksSection(userFile.getName(), config);
+
+		assertEquals(lastModified, userFile.lastModified());
+		assertTrue(config.isConfigurationSection("ItemBreaks.any"));
+	}
+
+	private void mockDefaultConfigResource() {
+		when(plugin.getResource("config-default.yml")).thenReturn(getClass().getResourceAsStream("/config-default.yml"));
 	}
 
 	private File createFileFromTestResource(String testResourceName) throws Exception {

--- a/advanced-achievements-plugin/src/test/java/com/hm/achievement/db/H2DatabaseManagerTest.java
+++ b/advanced-achievements-plugin/src/test/java/com/hm/achievement/db/H2DatabaseManagerTest.java
@@ -11,6 +11,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.PreparedStatement;
+import java.sql.Statement;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -235,8 +236,30 @@ class H2DatabaseManagerTest {
 	}
 
 	@Test
+	void testMigrateLegacyItemBreaksStatistics() throws Exception {
+		// Recreate the itembreaks table as it was before the category had sub-categories.
+		executeUpdate("DROP TABLE IF EXISTS itembreaks");
+		executeUpdate("DROP TABLE IF EXISTS itembreaks_legacy");
+		executeUpdate("CREATE TABLE itembreaks (playername char(36),itembreaks BIGINT,PRIMARY KEY (playername))");
+		executeUpdate("INSERT INTO itembreaks VALUES ('" + testUUID + "',12)");
+
+		db.initialise();
+
+		assertEquals(12, db.getMultipleAchievementAmount(testUUID, MultipleAchievements.ITEMBREAKS, "any"));
+		// A second initialisation must not attempt the migration again.
+		db.initialise();
+		assertEquals(12, db.getMultipleAchievementAmount(testUUID, MultipleAchievements.ITEMBREAKS, "any"));
+	}
+
+	@Test
 	void testGetDefaultJobsRebornAchievementAmount() {
 		assertEquals(1, db.getMultipleAchievementAmount(testUUID, MultipleAchievements.JOBSREBORN, "hunter"));
+	}
+
+	private void executeUpdate(String sql) throws Exception {
+		try (Statement st = db.getConnection().createStatement()) {
+			st.executeUpdate(sql);
+		}
 	}
 
 	private void clearDatabase() {

--- a/advanced-achievements-plugin/src/test/java/com/hm/achievement/utils/ItemFilterTest.java
+++ b/advanced-achievements-plugin/src/test/java/com/hm/achievement/utils/ItemFilterTest.java
@@ -1,0 +1,173 @@
+package com.hm.achievement.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.function.IntPredicate;
+import java.util.logging.Logger;
+
+import org.bukkit.DyeColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ItemFilterTest {
+
+	private static final Logger LOGGER = Logger.getLogger("ItemFilterTestLogger");
+	private static final MaterialHelper MATERIAL_HELPER = new MaterialHelper(LOGGER);
+
+	@Mock
+	private ItemStack itemStack;
+
+	@Mock
+	private ItemMeta itemMeta;
+
+	@Mock
+	private LeatherArmorMeta leatherArmorMeta;
+
+	@Test
+	void shouldMatchAnyItem() {
+		assertTrue(parse("any").matches(itemStack));
+	}
+
+	@Test
+	void shouldMatchMaterial() {
+		when(itemStack.getType()).thenReturn(Material.NETHERITE_LEGGINGS);
+
+		assertTrue(parse("netherite_leggings").matches(itemStack));
+	}
+
+	@Test
+	void shouldNotMatchOtherMaterial() {
+		when(itemStack.getType()).thenReturn(Material.WOODEN_HOE);
+
+		assertFalse(parse("material:netherite_leggings").matches(itemStack));
+	}
+
+	@Test
+	void shouldMatchOneOfTheGroupedMaterials() {
+		when(itemStack.getType()).thenReturn(Material.STONE_HOE);
+
+		assertTrue(parse("wooden_hoe|stone_hoe").matches(itemStack));
+	}
+
+	@Test
+	void shouldNotMatchUnknownCondition() {
+		assertFalse(parse("nonsense:value").matches(itemStack));
+	}
+
+	@Test
+	void shouldMatchEnchantmentName() {
+		assertTrue(ItemFilter.matchesEnchantmentName(NamespacedKey.minecraft("unbreaking"), "unbreaking"));
+		assertTrue(ItemFilter.matchesEnchantmentName(NamespacedKey.minecraft("mending"), "minecraft:mending"));
+		assertFalse(ItemFilter.matchesEnchantmentName(NamespacedKey.minecraft("mending"), "unbreaking"));
+	}
+
+	@Test
+	void shouldMatchExactEnchantmentLevel() {
+		IntPredicate level = ItemFilter.parseLevelPredicate("3", "wooden_hoe;enchant:unbreaking:3", LOGGER);
+
+		assertTrue(level.test(3));
+		assertFalse(level.test(2));
+		assertFalse(level.test(4));
+	}
+
+	@Test
+	void shouldMatchEnchantmentLevelWithOperator() {
+		assertTrue(ItemFilter.parseLevelPredicate(">=3", "enchant:unbreaking:>=3", LOGGER).test(4));
+		assertFalse(ItemFilter.parseLevelPredicate(">=3", "enchant:unbreaking:>=3", LOGGER).test(2));
+		assertTrue(ItemFilter.parseLevelPredicate("<2", "enchant:unbreaking:<2", LOGGER).test(1));
+		assertFalse(ItemFilter.parseLevelPredicate("<2", "enchant:unbreaking:<2", LOGGER).test(2));
+	}
+
+	@Test
+	void shouldNotMatchEnchantmentOfItemWithoutMeta() {
+		assertFalse(parse("enchant:unbreaking:3").matches(itemStack));
+	}
+
+	@Test
+	void shouldNotMatchEmptyEnchantmentCondition() {
+		assertFalse(parse("enchant:").matches(itemStack));
+	}
+
+	@Test
+	void shouldMatchCustomName() {
+		when(itemStack.getItemMeta()).thenReturn(itemMeta);
+		when(itemMeta.hasDisplayName()).thenReturn(true);
+		when(itemMeta.getDisplayName()).thenReturn("§5Purple Shorts");
+
+		assertTrue(parse("name:purple shorts").matches(itemStack));
+	}
+
+	@Test
+	void shouldMatchAnyCustomName() {
+		when(itemStack.getItemMeta()).thenReturn(itemMeta);
+		when(itemMeta.hasDisplayName()).thenReturn(true);
+
+		assertTrue(parse("name:*").matches(itemStack));
+	}
+
+	@Test
+	void shouldNotMatchItemWithoutCustomName() {
+		when(itemStack.getItemMeta()).thenReturn(itemMeta);
+		when(itemMeta.hasDisplayName()).thenReturn(false);
+
+		assertFalse(parse("name:Purple Shorts").matches(itemStack));
+	}
+
+	@Test
+	void shouldMatchDyedLeatherArmourWithName() {
+		when(itemStack.getType()).thenReturn(Material.LEATHER_LEGGINGS);
+		when(itemStack.getItemMeta()).thenReturn(leatherArmorMeta);
+		when(leatherArmorMeta.getColor()).thenReturn(DyeColor.PURPLE.getColor());
+		when(leatherArmorMeta.hasDisplayName()).thenReturn(true);
+		when(leatherArmorMeta.getDisplayName()).thenReturn("Purple Shorts");
+
+		assertTrue(
+				parse("leather_leggings;color:purple;name:Purple Shorts").matches(itemStack));
+	}
+
+	@Test
+	void shouldMatchHexadecimalColour() {
+		when(itemStack.getItemMeta()).thenReturn(leatherArmorMeta);
+		when(leatherArmorMeta.getColor()).thenReturn(DyeColor.PURPLE.getColor());
+
+		assertTrue(parse("color:#8932b8").matches(itemStack));
+	}
+
+	@Test
+	void shouldNotMatchOtherColour() {
+		when(itemStack.getItemMeta()).thenReturn(leatherArmorMeta);
+		when(leatherArmorMeta.getColor()).thenReturn(DyeColor.RED.getColor());
+
+		assertFalse(parse("color:purple").matches(itemStack));
+	}
+
+	@Test
+	void shouldNotMatchColourOfNonDyeableItem() {
+		when(itemStack.getItemMeta()).thenReturn(itemMeta);
+
+		assertFalse(parse("color:purple").matches(itemStack));
+	}
+
+	@Test
+	void shouldMatchUnbreakableItem() {
+		when(itemStack.getItemMeta()).thenReturn(itemMeta);
+		when(itemMeta.isUnbreakable()).thenReturn(true);
+
+		assertTrue(parse("unbreakable").matches(itemStack));
+	}
+
+	private static ItemFilter parse(String key) {
+		return ItemFilter.parse(key, MATERIAL_HELPER, LOGGER);
+	}
+
+}

--- a/advanced-achievements-plugin/src/test/java/com/hm/achievement/utils/ItemFilterTest.java
+++ b/advanced-achievements-plugin/src/test/java/com/hm/achievement/utils/ItemFilterTest.java
@@ -1,6 +1,8 @@
 package com.hm.achievement.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -164,6 +166,30 @@ class ItemFilterTest {
 		when(itemMeta.isUnbreakable()).thenReturn(true);
 
 		assertTrue(parse("unbreakable").matches(itemStack));
+	}
+
+	@Test
+	void shouldReturnTheMatchingAlternativeOfAGroup() {
+		when(itemStack.getType()).thenReturn(Material.STONE_HOE);
+
+		assertEquals("stone_hoe", parse("wooden_hoe|stone_hoe").matchingAlternative(itemStack));
+	}
+
+	@Test
+	void shouldReturnTheMatchingAlternativeAsWrittenWithoutItsSurroundingSpaces() {
+		when(itemStack.getType()).thenReturn(Material.WOODEN_HOE);
+		when(itemStack.getItemMeta()).thenReturn(itemMeta);
+		when(itemMeta.isUnbreakable()).thenReturn(true);
+
+		assertEquals("wooden_hoe;unbreakable",
+				parse("netherite_leggings | wooden_hoe;unbreakable").matchingAlternative(itemStack));
+	}
+
+	@Test
+	void shouldReturnNoAlternativeWhenTheItemMatchesNone() {
+		when(itemStack.getType()).thenReturn(Material.NETHERITE_LEGGINGS);
+
+		assertNull(parse("wooden_hoe|stone_hoe").matchingAlternative(itemStack));
 	}
 
 	private static ItemFilter parse(String key) {

--- a/advanced-achievements-plugin/src/test/resources/config-legacy-itembreaks.yml
+++ b/advanced-achievements-plugin/src/test/resources/config-legacy-itembreaks.yml
@@ -1,0 +1,16 @@
+# Count tools, armors or weapons broken.
+ItemBreaks:
+  1:
+    Goal: Let an item break.
+    Message: You broke your favorite tool!
+    Name: itembreaks_1
+    DisplayName: Clumsy Guy
+    Type: normal
+
+# Count items eaten (excludes potions and milk).
+EatenItems:
+  1:
+    Goal: Eat something.
+    Message: Time for a snack!
+    Name: eatenitems_1
+    Type: normal

--- a/advanced-achievements-plugin/src/test/resources/config-prefix-default.yml
+++ b/advanced-achievements-plugin/src/test/resources/config-prefix-default.yml
@@ -1,0 +1,12 @@
+#=============================================================#
+
+# Used for the Fish achievement category.
+FishableFish:
+  - cod
+  - salmon
+
+# Count fish caught.
+Fish:
+  1:
+    Goal: Fish a fish.
+    Name: fish_1

--- a/advanced-achievements-plugin/src/test/resources/config-prefix-user.yml
+++ b/advanced-achievements-plugin/src/test/resources/config-prefix-user.yml
@@ -1,0 +1,6 @@
+#=============================================================#
+
+# Used for the Fish achievement category.
+FishableFish:
+  - cod
+  - salmon


### PR DESCRIPTION
## What

`ItemBreaks` becomes a category with sub-categories that describe **which** item broke, so achievements can target a specific material, enchantment level, custom name or leather colour instead of counting every broken item.

A sub-category key is made of conditions separated by `;` (all must match), with alternatives separated by `|`:

| Condition | Example |
| --- | --- |
| `any` | `any` — any broken item |
| `<material>` / `material:<material>` | `netherite_leggings` |
| `enchant:<name>[:<level>]` | `enchant:mending`, `enchant:unbreaking:3`, `enchant:unbreaking:>=2` (`>=`, `<=`, `>`, `<` supported) |
| `name:<display name>` | `name:Purple Shorts` (case and colour codes ignored), `name:*` for any renamed item |
| `color:<colour>` | `color:purple`, `color:#8932b8`, `color:137,50,184` (dyed leather armour) |
| `unbreakable` | `unbreakable` |

```yaml
ItemBreaks:
  netherite_leggings:
    1: { Goal: ..., Name: itembreaks_1_netherite_leggings }
  "wooden_hoe;enchant:unbreaking:3":
    1: { Goal: ..., Name: itembreaks_1_unbreaking_wooden_hoe }
  "leather_leggings;color:purple;name:Purple Shorts":
    1: { Goal: ..., Name: itembreaks_1_purple_shorts }
```

Invalid conditions are logged as warnings and never match, so typos are visible instead of silently counting everything.

## Migration

Existing servers are converted automatically on startup:

- **Database**: the old `itembreaks` table is renamed to `itembreaks_legacy` (kept as a backup) and its statistics are copied into the `any` sub-category of the new table.
- **config.yml**: an `ItemBreaks` section still using thresholds directly is rewritten below the same `any` sub-category, keeping the achievement `Name`s so already awarded achievements stay valid.

## Notes

- Breaking API change: `NormalAchievements.ITEMBREAKS` no longer exists, the category is now `MultipleAchievements.ITEMBREAKS`.
- The permission is now `achievement.count.itembreaks.*`, with a child per sub-category key, whitespaces removed, e.g. `achievement.count.itembreaks.netherite_leggings` or `achievement.count.itembreaks.wooden_hoe;enchant:unbreaking:3` — the same scheme as the other categories with sub-categories.

## Also fixed here

`YamlUpdater.extractSectionForMissingKey` looked for a missing key with `startsWith(key)` rather than `startsWith(key + ":")`, so a key that is a prefix of another one matched the wrong line. The default config has both `Fish` and `FishableFish`: on a server whose `config.yml` predates the `Fish` category, the updater looked for `Fish`, found the `FishableFish:` line first and appended that section instead. `Fish` was still missing on the next startup, so it did it again — a config.yml I looked at had grown 22 copies of `FishableFish` and had still never gained `Fish`.

It is unrelated to the category change, but it lives in the file this PR already touches. The regression test also turned up an `IndexOutOfBoundsException` next door: the loop collecting a section's indented lines ran off the end of the file when the missing key was the last section of the default config. Both bounds are now checked.

## Tests

`mvn test`: 162 tests, 25 new (`ItemFilterTest`, database migration test in `H2DatabaseManagerTest`, config migration tests in `YamlUpdaterTest`). The 6 failures (`MaterialHelperTest`, `RewardParserTest`, `AdvancementJsonHelperTest`) are pre-existing on `master` — they need a running server.

